### PR TITLE
Add MongoDB config and user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Website: https://thenerdcave.us
 
 Want to contribute or submit requests for new videos! Join the [Discord](https://discord.gg/g7wr8xb) or send us an [email](mailto:contact@thenerdcave.us)!
 
+## Environment Variables
+
+The bot requires a MongoDB connection string provided through the
+`MONGO_URI` environment variable. Create a `.env` file or otherwise set
+this variable before starting the bot.
+
 # To-Do List:
 
 #### Enhance current help system

--- a/commands/register.js
+++ b/commands/register.js
@@ -1,28 +1,21 @@
 const { MessageEmbed } = require('discord.js');
+const { registerUser } = require('../utils');
 
 exports.run = async (client, message, args) => {
     const member = message.member;
-    const exists = await client.profileExists(member.id);
-
-    if (exists) {
-        return message.channel.send('You are already registered.');
-    }
-
-    const profile = {
-        guildID: member.guild.id,
-        guildName: member.guild.name,
-        userID: member.id,
-        username: member.user.tag,
-        joinDate: Date.now()
-    };
 
     // allow optional timezone offset argument
+    let offset = 0;
     if (args.length > 0) {
-        const offset = parseFloat(args[0]);
-        if (!isNaN(offset)) profile.tz_offset = offset;
+        const parsed = parseFloat(args[0]);
+        if (!isNaN(parsed)) offset = parsed;
     }
 
-    await client.createProfile(profile);
+    const created = await registerUser(client, member, offset);
+
+    if (!created) {
+        return message.channel.send('You are already registered.');
+    }
 
     const embed = new MessageEmbed()
         .setTitle('Registration complete')

--- a/commands/register.js
+++ b/commands/register.js
@@ -1,0 +1,37 @@
+const { MessageEmbed } = require('discord.js');
+
+exports.run = async (client, message, args) => {
+    const member = message.member;
+    const exists = await client.profileExists(member.id);
+
+    if (exists) {
+        return message.channel.send('You are already registered.');
+    }
+
+    const profile = {
+        guildID: member.guild.id,
+        guildName: member.guild.name,
+        userID: member.id,
+        username: member.user.tag,
+        joinDate: Date.now()
+    };
+
+    // allow optional timezone offset argument
+    if (args.length > 0) {
+        const offset = parseFloat(args[0]);
+        if (!isNaN(offset)) profile.tz_offset = offset;
+    }
+
+    await client.createProfile(profile);
+
+    const embed = new MessageEmbed()
+        .setTitle('Registration complete')
+        .setDescription('Your profile has been created.')
+        .setColor(0x36c98e);
+
+    message.channel.send(embed);
+};
+
+exports.help = {
+    name: 'register'
+};

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,19 +1,11 @@
+const { registerUser } = require('../utils');
+
 module.exports = async (client, member) => {
 
-    const newProfile = {
-        guildID: member.guild.id,
-        guildName: member.guild.name,
-        userID: member.id,
-        username: member.user.tag,
-        joinDate: Date.now()
-    };
-    
     try {
-        const exists = await client.profileExists(newProfile.userID);
-        if(!exists){
-            await client.createProfile(newProfile);
-        }else{
-            console.log(newProfile.username+" Rejoined!");
+        const created = await registerUser(client, member);
+        if (!created) {
+            console.log(member.user.tag + " Rejoined!");
         }
 
     } catch (err) {

--- a/events/message.js
+++ b/events/message.js
@@ -58,17 +58,12 @@ module.exports = async (client, message) => {
 };
 
 async function updateCoins(client, member, amount) {
-    const newProfile = {
-        guildID: member.guild.id,
-        guildName: member.guild.name,
-        userID: member.id,
-        username: member.user.tag,
-        joinDate: Date.now()
-    };
+    const { registerUser } = require('../utils');
 
     const profile = await client.getProfile(member);
-    if (!profile) await client.createProfile(newProfile);
-    const newAmount = profile ? profile.coins + amount : amount;
+    if (!profile) await registerUser(client, member);
+    const current = profile ? profile.coins : 0;
+    const newAmount = current + amount;
     await client.updateProfile(member, { coins: newAmount });
     //console.log(`Updated: ${newAmount}`);
 }

--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -6,6 +6,7 @@ const alphabet_array = require('../utils/alphabet_array');
 const {timezones_by_list,timezones_by_letter} = require('../utils/timezones')
 const menu_buttons = ['✅','❌'];
 const {spacePad,zeroPad} = require('../utils/paddings');
+const { registerUser } = require('../utils');
 
 
 module.exports = async (client, reaction, user) => {
@@ -14,6 +15,9 @@ module.exports = async (client, reaction, user) => {
 
     if(message.channel.guild){
         const member = message.channel.guild.members.cache.get(user.id);
+
+        // ensure a profile exists for the reacting user
+        await registerUser(client, member);
 
         if (member.user.bot) return;
         

--- a/models/profile.js
+++ b/models/profile.js
@@ -7,6 +7,11 @@ const profileSchema = mongoose.Schema({
     userID: String,
     username: String,
     joinDate: Number,
+    // Preferred timezone offset from UTC used for reminders
+    tz_offset: {
+        type: Number,
+        default: 0
+    },
     coins: {
         type: Number,
         default: 0

--- a/utils/index.js
+++ b/utils/index.js
@@ -3,5 +3,6 @@ module.exports = {
     ProgressBar: require('./Progress'),
     Timezones: require('./timezones'),
     AlphabetObject: require("./alphabet_object"),
-    AlphabetArray: require('./alphabet_array')
+    AlphabetArray: require('./alphabet_array'),
+    registerUser: require('./registerUser')
 };

--- a/utils/mongoose.js
+++ b/utils/mongoose.js
@@ -12,8 +12,12 @@ module.exports = {
             family: 4
         };
 
-        //mongoose.connect('mongodb://localhost:27017/stonks', dbOptions);
-        mongoose.connect('mongodb+srv://admin:'+process.env.MONGO_PW+'@cluster0.w3ynl.mongodb.net/DogeBot_SQL?retryWrites=true&w=majority', dbOptions);
+        // Support configuring the connection string through environment
+        // variables.  This makes it easier to spin up the bot with a new
+        // database without touching the source code.
+        const { mongoURI } = require('../config');
+
+        mongoose.connect(mongoURI, dbOptions);
         mongoose.set('useFindAndModify', false);
         mongoose.Promise = global.Promise;
         

--- a/utils/registerUser.js
+++ b/utils/registerUser.js
@@ -1,0 +1,19 @@
+const registerUser = async (client, member, tzOffset = 0) => {
+    const exists = await client.profileExists(member.id);
+    if (exists) return false;
+
+    const profile = {
+        guildID: member.guild.id,
+        guildName: member.guild.name,
+        userID: member.id,
+        username: member.user.tag,
+        joinDate: Date.now()
+    };
+
+    if (typeof tzOffset === 'number') profile.tz_offset = tzOffset;
+    await client.createProfile(profile);
+    return true;
+};
+
+module.exports = registerUser;
+


### PR DESCRIPTION
## Summary
- support `MONGO_URI` for DB connection
- track timezone preference in profiles
- add a `register` command to create a profile
- document required environment variable

## Testing
- `npm test` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6858147924a083318eff6030050198a0